### PR TITLE
#42 후원 정보 컴포넌트 (후원 상세 페이지)

### DIFF
--- a/src/components/DonationInfo.jsx
+++ b/src/components/DonationInfo.jsx
@@ -19,6 +19,61 @@ const DonationContext = createContext({
   isOpen: null,
 });
 
+/* 후원 정보 컴포넌트 사용법
+- 소개
+후원 정보 컴포넌트는 후원 상세 페이지에 쓰이는 컴포넌트입니다.
+모인 금액 타입과 모집 기간 타입을 지원합니다.
+1) 모집 금액 : 후원에 필요한 총 크레딧 수와 현재 모금 금액을 확인할 수 있고, 어느 정도 달성했는지 progress bar를 통해 직관적으로 확인합니다.
+2) 모집 기간 : 후원 마감 날짜와 현재 시점에서 기간이 얼마나 남았는지 타이머로 확인할 수 있습니다. 모집 시작부터 마감까지의 기간에서 지나온 시간을 progress bar로 확인합니다. 
+            (색이 채워진 부분이 지난 기간이고, 색이 모두 칠해지면 기간이 종료됨을 뜻합니다.)
+
+- 반응형 사용법
+s, m, l로 size를 설정해 사용할 수 있습니다. 기본 사이즈는 'l' 입니다. 
+
+*/
+
+/** 후원 정보 컴포넌트 props
+ *
+ * @typedef {Object} DonationInfoProps
+ * @property {string} props.title - [모집 금액 | 모집 기간] 후원 정보 제목 (ex. 모인 금액, 모집 기간)
+ * @property {string} props.subTitle - [모집 금액 | 모집 기간] 후원 정보 부제목 (ex. 크레딧, 남은 시간)
+ * @property {number} props.credit - [모집 금액] 모금액
+ * @property {number} props.targetAmount - [모집 금액]
+ * @property {string} props.createdAt - [모집 기간] 모집 시작 날짜 문자열 (ex. ISO 8601: YYYY-MM-DDTHH:mm:ss.sssZ)
+ * @property {string} props.deadline - [모집 기간] 모집 마감 날짜 문자열 (ex. ISO 8601: YYYY-MM-DDTHH:mm:ss.sssZ)
+ * @property {'s' | 'm' | 'l'} [size] - [모집 금액 | 모집 기간] 사이즈 (default size: l)
+ * @property {boolean} props.isOpen - [모집 금액 | 모집 기간] 후원 진행 여부
+ */
+
+/**
+ * @example
+ * 모집 종료 문구가 뜨는 시점은 isOpen이 false 상태일 때입니다.
+ * 1. 모집 금액
+ * <DonationInfo
+ *   title='모인 금액'
+ *   subTitle='크레딧'
+ *   credit={200000}
+ *   targetAmount={300000}
+ *   size='s'
+ *   isOpen={true}>
+ *   <DonationInfo.InfoCredit />
+ *   <DonationInfo.InfoTargetAmount />
+ * </DonationInfo>
+ *
+ * 2. 모집 기간
+ * 내부에서 dealine과 현시점을 계산하지 않습니다.
+ * 따라서 모집이 조기 종료될 경우엔 모집 기간의 isOpen도 false로 전달 받아야 합니다.
+ * <DonationInfo
+ *   title='모집 기간'
+ *   subTitle='남은 시간'
+ *   createdAt={'2025-03-19T00:00:00.891Z'}
+ *   deadline={'2025-05-22T23:59:59.000Z'}
+ *   size='l'
+ *   isOpen={true}>
+ *   <DonationInfo.InfoTimer />
+ *   <DonationInfo.InfoDeadline />
+ * </DonationInfo>
+ */
 const DonationInfo = ({
   title,
   subTitle,

--- a/src/components/DonationInfo.jsx
+++ b/src/components/DonationInfo.jsx
@@ -1,26 +1,12 @@
-import { useContext, createContext, memo } from 'react';
+import { useContext, createContext } from 'react';
+import { cn } from '@/utils/cn';
 import { useCountdownTimer } from '@hooks/useCountdownTimer';
-
-const getElapsedProgress = (createdAt, deadline, now) => {
-  const createdAtTime = new Date(createdAt).getTime();
-  const deadlineTime = new Date(deadline).getTime();
-
-  const totalDuration = deadlineTime - createdAtTime;
-  const elapsedTime = now - createdAtTime;
-  const progress = (elapsedTime / totalDuration) * 100;
-  const clampedProgress = Math.max(0, Math.min(progress, 100));
-
-  return clampedProgress;
-};
-
-const formatDate = (deadline) => {
-  const dateObj = new Date(deadline);
-  const year = dateObj.getFullYear();
-  const month = String(dateObj.getMonth() + 1).padStart(2, '0');
-  const day = String(dateObj.getDate()).padStart(2, '0');
-
-  return { year, month, day };
-};
+import {
+  DONATION_INFO_CONTENT_SIZE_STYLES,
+  DONATION_INFO_SUB_CONTENT_SIZE_STYLES,
+  DONATION_INFO_WIDTH_STYLES,
+} from '@constants/donationConstants';
+import { getElapsedProgress, formatDate } from '@utils/donationInfoUtils';
 
 const DonationContext = createContext({
   title: '',
@@ -29,6 +15,7 @@ const DonationContext = createContext({
   targetAmount: '',
   createdAt: '',
   deadline: '',
+  size: 'l',
   isOpen: null,
 });
 
@@ -39,6 +26,7 @@ const DonationInfo = ({
   targetAmount,
   createdAt,
   deadline,
+  size = 'l',
   isOpen,
   children,
 }) => {
@@ -49,14 +37,18 @@ const DonationInfo = ({
     targetAmount,
     createdAt,
     deadline,
+    size,
     isOpen,
   };
 
+  const donationInfoClassNames = cn(
+    'relative flex flex-col gap-3 text-white',
+    DONATION_INFO_WIDTH_STYLES[size],
+  );
+
   return (
     <DonationContext.Provider value={contextValue}>
-      <div className='relative flex w-[50rem] flex-col gap-3 text-white'>
-        {children}
-      </div>
+      <div className={donationInfoClassNames}>{children}</div>
     </DonationContext.Provider>
   );
 };
@@ -77,17 +69,20 @@ const InfoSubTitle = () => {
 
 // 크레딧 정보 컴포넌트
 const InfoCredit = () => {
-  const { credit, targetAmount, isOpen } = useContext(DonationContext);
+  const { credit, targetAmount, size, isOpen } = useContext(DonationContext);
   const progress = Math.min((credit / targetAmount) * 100, 100);
+
+  const infoCreditClassNames = cn(
+    'ml-auto font-extralight',
+    DONATION_INFO_CONTENT_SIZE_STYLES[size],
+  );
 
   return (
     <>
       {isOpen ? (
-        <p className='ml-auto text-8xl font-extralight'>
-          {credit.toLocaleString()}
-        </p>
+        <p className={infoCreditClassNames}>{credit.toLocaleString()}</p>
       ) : (
-        <p className='ml-auto text-8xl font-extralight'>모집 종료</p>
+        <p className={infoCreditClassNames}>모집 종료</p>
       )}
 
       <InfoProgressBar progress={progress}>
@@ -112,7 +107,7 @@ const InfoTargetAmount = () => {
 
 // 타이머 컴포넌트
 const InfoTimer = () => {
-  const { createdAt, deadline, isOpen } = useContext(DonationContext);
+  const { createdAt, deadline, size, isOpen } = useContext(DonationContext);
   const now = Date.now();
   const { days, hours, minutes, seconds } = useCountdownTimer(
     deadline,
@@ -121,20 +116,30 @@ const InfoTimer = () => {
   );
   const progress = getElapsedProgress(createdAt, deadline, now);
 
+  const infoTimerContentClassNames = cn(
+    'ml-auto font-extralight',
+    DONATION_INFO_CONTENT_SIZE_STYLES[size],
+  );
+
+  const infoTimerSubContentClassNames = cn(
+    'mr-5',
+    DONATION_INFO_SUB_CONTENT_SIZE_STYLES[size],
+  );
+
   const isClosedText = (
-    <span className='ml-auto text-8xl font-extralight'>모집 종료</span>
+    <span className={infoTimerContentClassNames}>모집 종료</span>
   );
 
   const timerText = (
-    <p className='ml-auto text-8xl font-extralight'>
+    <p className={infoTimerContentClassNames}>
       {days}
-      <span className='mr-5 text-6xl text-white'>일</span>
+      <span className={infoTimerSubContentClassNames}>일</span>
       {hours}
-      <span className='mr-5 text-6xl text-white'>시</span>
+      <span className={infoTimerSubContentClassNames}>시</span>
       {minutes}
-      <span className='mr-5 text-6xl text-white'>분</span>
+      <span className={infoTimerSubContentClassNames}>분</span>
       {seconds}
-      <span className='text-6xl text-white'>초</span>
+      <span className={DONATION_INFO_SUB_CONTENT_SIZE_STYLES[size]}>초</span>
     </p>
   );
 
@@ -182,5 +187,3 @@ DonationInfo.InfoDeadline = InfoDeadline;
 DonationInfo.InfoProgressBar = InfoProgressBar;
 
 export default DonationInfo;
-
-// * todo : 사이즈

--- a/src/components/DonationInfo.jsx
+++ b/src/components/DonationInfo.jsx
@@ -1,0 +1,186 @@
+import { useContext, createContext, memo } from 'react';
+import { useCountdownTimer } from '@hooks/useCountdownTimer';
+
+const getElapsedProgress = (createdAt, deadline, now) => {
+  const createdAtTime = new Date(createdAt).getTime();
+  const deadlineTime = new Date(deadline).getTime();
+
+  const totalDuration = deadlineTime - createdAtTime;
+  const elapsedTime = now - createdAtTime;
+  const progress = (elapsedTime / totalDuration) * 100;
+  const clampedProgress = Math.max(0, Math.min(progress, 100));
+
+  return clampedProgress;
+};
+
+const formatDate = (deadline) => {
+  const dateObj = new Date(deadline);
+  const year = dateObj.getFullYear();
+  const month = String(dateObj.getMonth() + 1).padStart(2, '0');
+  const day = String(dateObj.getDate()).padStart(2, '0');
+
+  return { year, month, day };
+};
+
+const DonationContext = createContext({
+  title: '',
+  subTitle: '',
+  credit: '',
+  targetAmount: '',
+  createdAt: '',
+  deadline: '',
+  isOpen: null,
+});
+
+const DonationInfo = ({
+  title,
+  subTitle,
+  credit,
+  targetAmount,
+  createdAt,
+  deadline,
+  isOpen,
+  children,
+}) => {
+  const contextValue = {
+    title,
+    subTitle,
+    credit,
+    targetAmount,
+    createdAt,
+    deadline,
+    isOpen,
+  };
+
+  return (
+    <DonationContext.Provider value={contextValue}>
+      <div className='relative flex w-[50rem] flex-col gap-3 text-white'>
+        {children}
+      </div>
+    </DonationContext.Provider>
+  );
+};
+
+// 제목 컴포넌트
+const InfoTitle = () => {
+  const { title } = useContext(DonationContext);
+
+  return <p className='content-text font-bold'>{title}</p>;
+};
+
+// 소제목 컴포넌트
+const InfoSubTitle = () => {
+  const { subTitle } = useContext(DonationContext);
+
+  return <p className='content-text absolute right-0 opacity-50'>{subTitle}</p>;
+};
+
+// 크레딧 정보 컴포넌트
+const InfoCredit = () => {
+  const { credit, targetAmount, isOpen } = useContext(DonationContext);
+  const progress = Math.min((credit / targetAmount) * 100, 100);
+
+  return (
+    <>
+      {isOpen ? (
+        <p className='ml-auto text-8xl font-extralight'>
+          {credit.toLocaleString()}
+        </p>
+      ) : (
+        <p className='ml-auto text-8xl font-extralight'>모집 종료</p>
+      )}
+
+      <InfoProgressBar progress={progress}>
+        <div className='bg-brand-2 z-100 ml-auto h-fit w-fit rounded-full px-3 py-1 text-[1rem] whitespace-nowrap'>
+          {progress.toFixed(1)} %
+        </div>
+      </InfoProgressBar>
+    </>
+  );
+};
+
+// 목표 금액 컴포넌트
+const InfoTargetAmount = () => {
+  const { targetAmount } = useContext(DonationContext);
+
+  return (
+    <p className='content-text ml-auto'>
+      목표 금액 {targetAmount.toLocaleString()}
+    </p>
+  );
+};
+
+// 타이머 컴포넌트
+const InfoTimer = () => {
+  const { createdAt, deadline, isOpen } = useContext(DonationContext);
+  const now = Date.now();
+  const { days, hours, minutes, seconds } = useCountdownTimer(
+    deadline,
+    now,
+    isOpen,
+  );
+  const progress = getElapsedProgress(createdAt, deadline, now);
+
+  const isClosedText = (
+    <span className='ml-auto text-8xl font-extralight'>모집 종료</span>
+  );
+
+  const timerText = (
+    <p className='ml-auto text-8xl font-extralight'>
+      {days}
+      <span className='mr-5 text-6xl text-white'>일</span>
+      {hours}
+      <span className='mr-5 text-6xl text-white'>시</span>
+      {minutes}
+      <span className='mr-5 text-6xl text-white'>분</span>
+      {seconds}
+      <span className='text-6xl text-white'>초</span>
+    </p>
+  );
+
+  return (
+    <>
+      {isOpen ? timerText : isClosedText}
+      <InfoProgressBar progress={progress} />
+    </>
+  );
+};
+
+// 마감 날짜 컴포넌트
+const InfoDeadline = () => {
+  const { deadline } = useContext(DonationContext);
+  const { year, month, day } = formatDate(deadline);
+
+  return (
+    <p className='content-text ml-auto'>
+      마감 날짜 {`${year}.${month}.${day}`}
+    </p>
+  );
+};
+
+// 진행 바 컴포넌트
+const InfoProgressBar = ({ progress, children }) => {
+  return (
+    <div className='relative mt-5 mb-1 h-4 w-full rounded-full'>
+      <div
+        className='bg-gradient-brand absolute z-1 flex h-4 items-center rounded-full'
+        style={{ width: `${progress}%` }} // tailwindcss는 동적으로 스타일을 줄 수 없습니다.
+      >
+        {children}
+      </div>
+      <div className='h-4 w-full rounded-full bg-white opacity-30'></div>
+    </div>
+  );
+};
+
+DonationInfo.InfoTitle = InfoTitle;
+DonationInfo.InfoSubTitle = InfoSubTitle;
+DonationInfo.InfoCredit = InfoCredit;
+DonationInfo.InfoTargetAmount = InfoTargetAmount;
+DonationInfo.InfoTimer = InfoTimer;
+DonationInfo.InfoDeadline = InfoDeadline;
+DonationInfo.InfoProgressBar = InfoProgressBar;
+
+export default DonationInfo;
+
+// * todo : 사이즈

--- a/src/components/DonationInfo.jsx
+++ b/src/components/DonationInfo.jsx
@@ -103,7 +103,11 @@ const DonationInfo = ({
 
   return (
     <DonationContext.Provider value={contextValue}>
-      <div className={donationInfoClassNames}>{children}</div>
+      <div className={donationInfoClassNames}>
+        <InfoTitle />
+        <InfoSubTitle />
+        {children}
+      </div>
     </DonationContext.Provider>
   );
 };

--- a/src/components/DonationInfo.jsx
+++ b/src/components/DonationInfo.jsx
@@ -62,7 +62,7 @@ s, m, l로 size를 설정해 사용할 수 있습니다. 기본 사이즈는 'l'
  * </DonationInfo>
  *
  * 2. 모집 기간
- * 내부에서 dealine과 현시점을 계산하지 않습니다.
+ * 내부에서 deadline과 현시점을 계산하지 않습니다.
  * 따라서 모집이 조기 종료될 경우엔 모집 기간의 isOpen도 false로 전달 받아야 합니다.
  * <DonationInfo
  *   title='모집 기간'

--- a/src/components/DonationInfo.jsx
+++ b/src/components/DonationInfo.jsx
@@ -5,6 +5,7 @@ import {
   DONATION_INFO_CONTENT_SIZE_STYLES,
   DONATION_INFO_SUB_CONTENT_SIZE_STYLES,
   DONATION_INFO_WIDTH_STYLES,
+  MAX_PROGRESS_PERCENT,
 } from '@constants/donationConstants';
 import { getElapsedProgress, formatDate } from '@utils/donationInfoUtils';
 
@@ -129,7 +130,10 @@ const InfoSubTitle = () => {
 // 크레딧 정보 컴포넌트
 const InfoCredit = () => {
   const { credit, targetAmount, size, isOpen } = useContext(DonationContext);
-  const progress = Math.min((credit / targetAmount) * 100, 100);
+  const progress = Math.min(
+    (credit / targetAmount) * MAX_PROGRESS_PERCENT,
+    MAX_PROGRESS_PERCENT,
+  );
 
   const infoCreditClassNames = cn(
     'ml-auto font-extralight',

--- a/src/components/DonationInfo.jsx
+++ b/src/components/DonationInfo.jsx
@@ -172,11 +172,7 @@ const InfoTargetAmount = () => {
 const InfoTimer = () => {
   const { createdAt, deadline, size, isOpen } = useContext(DonationContext);
   const now = Date.now();
-  const { days, hours, minutes, seconds } = useCountdownTimer(
-    deadline,
-    now,
-    isOpen,
-  );
+  const { days, hours, minutes, seconds } = useCountdownTimer(deadline, isOpen);
   const progress = getElapsedProgress(createdAt, deadline, now);
 
   const infoTimerContentClassNames = cn(

--- a/src/constants/donationConstants.js
+++ b/src/constants/donationConstants.js
@@ -1,0 +1,17 @@
+export const DONATION_INFO_CONTENT_SIZE_STYLES = {
+  s: 'text-5xl',
+  m: 'text-6xl',
+  l: 'text-8xl',
+};
+
+export const DONATION_INFO_SUB_CONTENT_SIZE_STYLES = {
+  s: 'text-3xl',
+  m: 'text-4xl',
+  l: 'text-6xl',
+};
+
+export const DONATION_INFO_WIDTH_STYLES = {
+  s: 'w-[25rem]',
+  m: 'w-[30rem]',
+  l: 'w-[50rem]',
+};

--- a/src/constants/donationConstants.js
+++ b/src/constants/donationConstants.js
@@ -15,3 +15,10 @@ export const DONATION_INFO_WIDTH_STYLES = {
   m: 'w-[30rem]',
   l: 'w-[50rem]',
 };
+
+export const MAX_PROGRESS_PERCENT = 100;
+
+export const SECOND = 1000;
+export const MINUTE = SECOND * 60;
+export const HOUR = MINUTE * 60;
+export const DAY = HOUR * 24;

--- a/src/hooks/useCountdownTimer.js
+++ b/src/hooks/useCountdownTimer.js
@@ -1,10 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useWebWorkerTimer } from '@/hooks/useWebWorkerTimer';
-
-const SECOND = 1000;
-const MINUTE = SECOND * 60;
-const HOUR = MINUTE * 60;
-const DAY = HOUR * 24;
+import { SECOND, MINUTE, HOUR, DAY } from '@constants/donationConstants';
 
 export const useCountdownTimer = (deadline, now, isOpen) => {
   const emptyTime = { days: 0, hours: 0, minutes: 0, seconds: 0 }; // 리렌더링 방지용 (타이머 방지)
@@ -12,7 +8,7 @@ export const useCountdownTimer = (deadline, now, isOpen) => {
     isOpen ? calculateRemaining(deadline, now) : emptyTime,
   );
 
-  const timer = useWebWorkerTimer(isOpen ? 1000 : null);
+  const timer = useWebWorkerTimer(isOpen ? SECOND : null);
 
   useEffect(() => {
     if (!isOpen || timer === null) return;

--- a/src/hooks/useCountdownTimer.js
+++ b/src/hooks/useCountdownTimer.js
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react';
+import { useWebWorkerTimer } from '@/hooks/useWebWorkerTimer';
+
+const SECOND = 1000;
+const MINUTE = SECOND * 60;
+const HOUR = MINUTE * 60;
+const DAY = HOUR * 24;
+
+export const useCountdownTimer = (deadline, now, isOpen) => {
+  const emptyTime = { days: 0, hours: 0, minutes: 0, seconds: 0 }; // 리렌더링 방지용 (타이머 방지)
+  const [remainingTime, setRemainingTime] = useState(() =>
+    isOpen ? calculateRemaining(deadline, now) : emptyTime,
+  );
+
+  const timer = useWebWorkerTimer(isOpen ? 1000 : null);
+
+  useEffect(() => {
+    if (!isOpen || timer === null) return;
+
+    setRemainingTime(calculateRemaining(deadline, now));
+  }, [timer, isOpen, deadline]);
+
+  return remainingTime;
+};
+
+const calculateRemaining = (deadline, now) => {
+  const deadlineObj = new Date(deadline);
+  const diff = deadlineObj - now;
+
+  return {
+    days: Math.floor(diff / DAY),
+    hours: Math.floor((diff % DAY) / HOUR),
+    minutes: Math.floor((diff % HOUR) / MINUTE),
+    seconds: Math.floor((diff % MINUTE) / SECOND),
+  };
+};

--- a/src/hooks/useCountdownTimer.js
+++ b/src/hooks/useCountdownTimer.js
@@ -2,26 +2,39 @@ import { useState, useEffect } from 'react';
 import { useWebWorkerTimer } from '@/hooks/useWebWorkerTimer';
 import { SECOND, MINUTE, HOUR, DAY } from '@constants/donationConstants';
 
-export const useCountdownTimer = (deadline, now, isOpen) => {
-  const emptyTime = { days: 0, hours: 0, minutes: 0, seconds: 0 }; // 리렌더링 방지용 (타이머 방지)
-  const [remainingTime, setRemainingTime] = useState(() =>
-    isOpen ? calculateRemaining(deadline, now) : emptyTime,
-  );
+const emptyTime = { days: 0, hours: 0, minutes: 0, seconds: 0 };
 
-  const timer = useWebWorkerTimer(isOpen ? SECOND : null);
+/**
+ * @param {string} deadline - ISO 형식의 마감 시각
+ * @param {boolean} isOpen - 후원 진행 상태
+ * @returns {Object} { days, hours, minutes, seconds }
+ */
+export const useCountdownTimer = (deadline, isOpen) => {
+  const timer = useWebWorkerTimer(isOpen ? SECOND : null); // 타이머 값을 기준으로 초기 상태를 계산하려면 반드시 timer를 먼저 정의 (1초마다 업데이트)
+
+  const [remainingTime, setRemainingTime] = useState(() =>
+    isOpen && timer ? calculateRemaining(deadline, timer) : emptyTime,
+  );
 
   useEffect(() => {
     if (!isOpen || timer === null) return;
 
-    setRemainingTime(calculateRemaining(deadline, now));
+    setRemainingTime(calculateRemaining(deadline, timer));
   }, [timer, isOpen, deadline]);
 
   return remainingTime;
 };
 
-const calculateRemaining = (deadline, now) => {
+const calculateRemaining = (deadline, nowTimestamp) => {
   const deadlineObj = new Date(deadline);
+  const now = new Date(nowTimestamp);
   const diff = deadlineObj - now;
+
+  if (diff <= 0) {
+    // deadline이 now보다 과거라면 0:0:0:0으로 초기화하여 음수 값이 나오는 것을 방지.
+    // 단, 타이머는 계속 진행되므로 외부에서 isOpen을 처리하는 것이 우선. (즉, 정리하면 메모리 누수 방지는 사용처에서 isOpen으로 관리한다.)
+    return emptyTime;
+  }
 
   return {
     days: Math.floor(diff / DAY),

--- a/src/hooks/useWebWorkerTimer.js
+++ b/src/hooks/useWebWorkerTimer.js
@@ -1,0 +1,29 @@
+import { useEffect, useRef, useState } from 'react';
+import TimerWorker from '../libs/timerWorker?worker';
+
+export const useWebWorkerTimer = (interval = 1000) => {
+  const [now, setNow] = useState(Date.now());
+  const workerRef = useRef(null);
+
+  useEffect(() => {
+    if (interval === null) return;
+
+    const worker = new TimerWorker();
+    workerRef.current = worker;
+
+    worker.postMessage({ type: 'start', interval });
+
+    worker.onmessage = (e) => {
+      if (e.data.type === 'tick') {
+        setNow(e.data.timestamp);
+      }
+    };
+
+    return () => {
+      worker.postMessage({ type: 'stop' });
+      worker.terminate();
+    };
+  }, [interval]);
+
+  return now;
+};

--- a/src/libs/timerWorker.js
+++ b/src/libs/timerWorker.js
@@ -1,0 +1,17 @@
+let intervalId = null;
+
+self.onmessage = (e) => {
+  const { type, interval } = e.data;
+
+  if (type === 'start') {
+    clearInterval(intervalId);
+    intervalId = setInterval(() => {
+      self.postMessage({ type: 'tick', timestamp: Date.now() });
+    }, interval);
+  }
+
+  if (type === 'stop') {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+};

--- a/src/utils/donationInfoUtils.js
+++ b/src/utils/donationInfoUtils.js
@@ -1,0 +1,20 @@
+export const getElapsedProgress = (createdAt, deadline, now) => {
+  const createdAtTime = new Date(createdAt).getTime();
+  const deadlineTime = new Date(deadline).getTime();
+
+  const totalDuration = deadlineTime - createdAtTime;
+  const elapsedTime = now - createdAtTime;
+  const progress = (elapsedTime / totalDuration) * 100;
+  const clampedProgress = Math.max(0, Math.min(progress, 100));
+
+  return clampedProgress;
+};
+
+export const formatDate = (deadline) => {
+  const dateObj = new Date(deadline);
+  const year = dateObj.getFullYear();
+  const month = String(dateObj.getMonth() + 1).padStart(2, '0');
+  const day = String(dateObj.getDate()).padStart(2, '0');
+
+  return { year, month, day };
+};


### PR DESCRIPTION
### 📌 관련 이슈
- #42

### 📋 작업 내용
- 후원 정보 컴포넌트 (모인 금액)
- 후원 정보 컴포넌트 (모집 기간)
- 사이즈 : s, m, l

### 📷 결과 및 스크린샷
![후원 정보 컴포넌트 pr](https://github.com/user-attachments/assets/bf710ff9-9c27-4bc6-8555-9aa5e14265f3)


### 🔎 참고 (선택)
- 이번 프로젝트에서 재사용 컴포넌트의 기준을 '페이지에 상관없이 2번 이상 사용되는 컴포넌트'로 정했고, 후원 정보 컴포넌트는 한 페이지에서 2번 사용됩니다. 하지만 사실 한 페이지에서만 사용되는데, 컴포넌트 외에 내부에서 사용되는 함수나 훅 같은 로직들도 같이 재사용 로직으로 분리되는게 맞는가? 하는 고민이 들었습니다. 그래서 우선 모든 파일 구조를 재사용 컴포넌트를 기준으로 삼았지만, 파일/디렉토리 구조에 대한 피드백 부탁드립니다!
- 타이머는 웹 워커를 기반으로 제작되었습니다. setInterval를 사용하려고 했지만, 타이머가 진행될 수록 오차가 생기고 브라우저에서 탭이 백그라운드로 처리되면서 타이머가 느려지는 경우가 있다고 하여 웹 워커를 선택했습니다. 
- 타이머는 1초마다 리렌더링이 되어야 하는데, 합성 컴포넌트로 구현했기 때문에 모집 중일 때 타이머와 기간 progress bar 부분만 리렌더링 되도록 신경써서 구현했습니다.