### PR TITLE
#48 후원 제목 컴포넌트 (후원 상세 페이지)

### DIFF
--- a/src/pages/detail-page/components/DetailTitle.jsx
+++ b/src/pages/detail-page/components/DetailTitle.jsx
@@ -1,0 +1,30 @@
+import { cn } from '@/utils/cn';
+
+const DETAIL_TITLE_WIDTH_STYLES = {
+  s: 'items-start w-full text-start pb-4 border-b-1 border-[rgba(255,255,255,0.3)]',
+  l: 'items-end w-[60rem] text-end',
+};
+
+const DETAIL_TITLE_SIZE_STYLES = {
+  s: 'text-5xl',
+  l: 'text-7xl',
+};
+
+const DetailTitle = ({ name, title, location, size = 'l' }) => {
+  const DetailTitleWidthClassNames = cn(
+    'flex flex-col gap-4 text-white',
+    DETAIL_TITLE_WIDTH_STYLES[size],
+  );
+
+  const DetailTitleClassNames = cn('text-bold', DETAIL_TITLE_SIZE_STYLES[size]);
+
+  return (
+    <div className={DetailTitleWidthClassNames}>
+      <p className='text-3xl opacity-60'>{name}</p>
+      <p className={DetailTitleClassNames}>{title}</p>
+      <p className='text-4xl opacity-60'>{location}</p>
+    </div>
+  );
+};
+
+export default DetailTitle;

--- a/src/pages/detail-page/components/DetailTitle.jsx
+++ b/src/pages/detail-page/components/DetailTitle.jsx
@@ -10,6 +10,25 @@ const DETAIL_TITLE_SIZE_STYLES = {
   l: 'text-7xl',
 };
 
+/**
+ * 후원 제목 컴포넌트 (세부)
+ * @component
+ * @param {string} props.title - 후원 제목
+ * @param {string} props.name - 아이돌 그룹명 + 이름
+ * @param {string} props.location - 후원 장소
+ * @param {'s' | 'l'} [props.size='l'] - 후원 제목 크기 (default size: 'l')
+ *
+ * @example
+ * 's' 사이즈는 w-full로 되어있고, 'l' 사이즈는 w-[60rem]으로 고정되어 있습니다.
+ *
+ * <DetailTitle
+ *   name='에스파 카리나'
+ *   title='1주년 기념 팝업 카페'
+ *   location='홍대 AK 플라자'
+ *   size='s'
+ * />
+ */
+
 const DetailTitle = ({ name, title, location, size = 'l' }) => {
   const DetailTitleWidthClassNames = cn(
     'flex flex-col gap-4 text-white',

--- a/src/pages/detail-page/components/MainTitle.jsx
+++ b/src/pages/detail-page/components/MainTitle.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useState } from 'react';
+import { cn } from '@/utils/cn';
+
+const MAIN_TITLE_SIZE_STYLES = {
+  s: 'text-3xl',
+  m: 'text-4xl',
+  l: 'text-5xl',
+};
+
+const MainTitle = ({ title, name, size = 's' }) => {
+  const containerRef = useRef(null);
+  const textRef = useRef(null);
+  const [fontSize, setFontSize] = useState(100);
+
+  // 이름이 부모 컨테이너의 width에 꽉 차도록 폰트 사이즈 수정하기 (반응형 단위를 사용할 경우 텍스트가 넘칠 수 있다.)
+  useEffect(() => {
+    const containerWidth = containerRef.current.offsetWidth;
+    const textWidth = textRef.current.scrollWidth;
+
+    const ratio = containerWidth / textWidth;
+    const newFontSize = Math.floor(100 * Math.min(ratio, 1.7)); // 최대 크기 지정
+
+    setFontSize(newFontSize);
+  }, [name]);
+
+  const titleClassNames = cn('mb-2', MAIN_TITLE_SIZE_STYLES[size]);
+
+  return (
+    <div className='w-[60vw] text-white'>
+      <p className={titleClassNames}>{title}</p>
+      <div
+        ref={containerRef}
+        className='h-fit w-full font-thin tracking-tighter'
+      >
+        <p
+          ref={textRef}
+          style={{
+            fontSize: `${fontSize}px`,
+            whiteSpace: 'nowrap',
+            display: 'inline-block',
+            lineHeight: '0.75',
+          }}
+        >
+          {name}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default MainTitle;

--- a/src/pages/detail-page/components/MainTitle.jsx
+++ b/src/pages/detail-page/components/MainTitle.jsx
@@ -7,6 +7,17 @@ const MAIN_TITLE_SIZE_STYLES = {
   l: 'text-5xl',
 };
 
+/**
+ * 후원 제목 컴포넌트 (메인)
+ * @component
+ * @param {string} props.title - 후원 제목
+ * @param {string} props.name - 아이돌 그룹명 + 이름
+ * @param {'s' | 'm' | 'l'} [props.size='s'] - 후원 제목 사이즈 (default size: 's')
+ *
+ * @example
+ * <MainTitle title='1주년 기념 팝업 카페' name='KARINA' size='s' />
+ */
+
 const MainTitle = ({ title, name, size = 's' }) => {
   const containerRef = useRef(null);
   const textRef = useRef(null);


### PR DESCRIPTION
### 📌 관련 이슈
- #48

### 📋 작업 내용
- 후원 제목 컴포넌트 (메인) 
  - size(s / m / l)는 후원 제목의 크기를 뜻합니다. 
  - 아이돌 이름은 항상 화면의 60vw로 설정해두었습니다.
  - 이름이 길어질 경우엔 부모 컨테이너에 맞춰서 글자 크기가 줄어들도록 설정했습니다.
- 후원 제목 컴포넌트 (상세)

### 📷 결과 및 스크린샷
|후원 제목 컴포넌트|스크린샷|
|---|---|
|메인|<img width="751" alt="image" src="https://github.com/user-attachments/assets/c2b76c62-79f5-42bb-8370-569036e8ba1b" />|
|상세 (PC)|<img width="517" alt="image" src="https://github.com/user-attachments/assets/58ef96e1-0755-4403-ba63-9a11a884ce9c" />
|상세 (Tablet, Mobile)|<img width="278" alt="image" src="https://github.com/user-attachments/assets/b71f4148-98cc-41ff-aa8d-c450304c2db0" />|


### 🔎 참고 (선택)
