### PR TITLE
Feat/64 반응형 캐러셀 구현 및 캐러셀이 동작하지 않는 버그 수정

### DIFF
--- a/src/apis/donateApi.js
+++ b/src/apis/donateApi.js
@@ -1,0 +1,16 @@
+import { instance } from './instance';
+
+export const getDonate = async ({
+  cursor = 0,
+  pageSize = 16,
+  keyword = '',
+} = {}) => {
+  try {
+    const { data } = await instance.get(`/donations`, {
+      params: { cursor, pageSize, keyword },
+    });
+    return data;
+  } catch (error) {
+    throw new Error(`도네이션 목록 불러오기 실패: ${error.message}`);
+  }
+};

--- a/src/components/common/Carousel.jsx
+++ b/src/components/common/Carousel.jsx
@@ -34,7 +34,6 @@ const Carousel = ({
   RenderComponent,
   slideToShow = 4, // 기본값으로 4개 표시
   gap = 4, // 아이템 간격
-  itemClassName = '', // 추가 스타일링을 위한 클래스
   button,
   ...props
 }) => {
@@ -89,11 +88,10 @@ const Carousel = ({
           duration: 0.5,
         }}
       >
-        {data.map((item, index) => (
+        {data.map((item) => (
           <motion.div
             key={item.id}
             style={{ minWidth: itemWidth, width: itemWidth }}
-            className={`${itemClassName}`}
           >
             {RenderComponent && (
               <RenderComponent

--- a/src/components/common/Carousel.jsx
+++ b/src/components/common/Carousel.jsx
@@ -3,6 +3,7 @@ import { useCarousel } from '@hooks/useCarousel';
 import IdolCardList from '@components/card/IdolCard';
 import ChevronLeft from '@assets/icons/icon_chevron-left';
 import ChevronRight from '@assets/icons/icon_chevron-right';
+import { useState, useEffect } from 'react';
 
 /**
  * Carousel 컴포넌트
@@ -37,6 +38,26 @@ const Carousel = ({
   button,
   ...props
 }) => {
+  const [responsiveOffset, setResponsiveOffset] = useState(slideToShow);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 1024) {
+        setResponsiveOffset(4);
+      } else if (window.innerWidth >= 768) {
+        setResponsiveOffset(3);
+      } else if (window.innerWidth >= 640) {
+        setResponsiveOffset(2);
+      } else {
+        setResponsiveOffset(1);
+      }
+    };
+    handleResize();
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
   const {
     currentIndex,
     width,
@@ -44,15 +65,19 @@ const Carousel = ({
     isTransitioning,
     nextSlide,
     prevSlide,
-  } = useCarousel({ totalDataLength: data?.length, offset: slideToShow });
+  } = useCarousel({
+    totalDataLength: data?.length,
+    offset: responsiveOffset,
+    data,
+  });
 
   // 아이템 너비 계산 (카드 너비를 이정하게 유지하고 싶다면)
-  const itemWidth = `calc((100% - ${(slideToShow - 1) * gap}px) / ${slideToShow})`;
+  const itemWidth = `calc((100% - ${(responsiveOffset - 1) * gap}px) / ${responsiveOffset})`;
 
   if (!data) return null;
 
   return (
-    <div className='relative p-10'>
+    <div className='relative'>
       <motion.div
         ref={carouselRef}
         className={`flex ${gap > 0 ? `gap-${gap}` : ''}`}
@@ -60,9 +85,7 @@ const Carousel = ({
           x: currentIndex * -width,
         }}
         transition={{
-          type: 'spring',
-          stiffness: 300,
-          damping: 30,
+          type: 'tween',
           duration: 0.5,
         }}
       >
@@ -70,7 +93,7 @@ const Carousel = ({
           <motion.div
             key={item.id}
             style={{ minWidth: itemWidth, width: itemWidth }}
-            className={itemClassName}
+            className={`${itemClassName}`}
           >
             {RenderComponent && (
               <RenderComponent

--- a/src/hooks/useCarousel.jsx
+++ b/src/hooks/useCarousel.jsx
@@ -12,6 +12,7 @@ import { useEffect, useRef, useState, useCallback } from 'react';
  */
 
 export const useCarousel = ({ totalDataLength, offset, data }) => {
+  const DURATION = 5000;
   // 보여줄 페이지 위치
   const [currentIndex, setCurrentIndex] = useState(0);
   const [width, setWidth] = useState(200);
@@ -46,7 +47,7 @@ export const useCarousel = ({ totalDataLength, offset, data }) => {
     } else {
       setCurrentIndex(currentIndex + 1);
     }
-    setTimeout(() => setIsTransitioning(false), 500);
+    setTimeout(() => setIsTransitioning(false), DURATION);
   };
 
   const prevSlide = () => {
@@ -57,7 +58,7 @@ export const useCarousel = ({ totalDataLength, offset, data }) => {
     } else {
       setCurrentIndex(currentIndex - 1);
     }
-    setTimeout(() => setIsTransitioning(false), 500);
+    setTimeout(() => setIsTransitioning(false), DURATION);
   };
 
   return {

--- a/src/hooks/useCarousel.jsx
+++ b/src/hooks/useCarousel.jsx
@@ -1,4 +1,10 @@
-import { useEffect, useRef, useState } from 'react';
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useCallback,
+} from 'react';
 /**
  * @typedef {Object} CarouselOptions
  * @property {number} totalDataLength - 캐러셀에 표시할 전체 데이터 항목의 수
@@ -11,58 +17,55 @@ import { useEffect, useRef, useState } from 'react';
  * @property {number} width - 각 캐러셀 항목의 너비 (픽셀셀)
  */
 
-export const useCarousel = ({ totalDataLength, offset }) => {
+export const useCarousel = ({ totalDataLength, offset, data }) => {
   // 보여줄 페이지 위치
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [width, setWidth] = useState(0);
+  const [width, setWidth] = useState(200);
   // 애니메이션 중복 방지를 위한 상태 관리
   const [isTransitioning, setIsTransitioning] = useState(false);
   //캐러셀의 width를 지정해주기 위한 ref
   const carouselRef = useRef(null);
 
-  //
-  useEffect(() => {
+  const calculateWidth = useCallback(() => {
     if (carouselRef.current) {
-      // 캐러셀 전체의 넓이 / 한 번에 보여줄 수 있는 카드 수
       const cardWidth = carouselRef.current.offsetWidth / offset;
       setWidth(cardWidth);
     }
-  }, []);
+  }, [offset]);
+
+  useEffect(() => {
+    if (!data?.length) return;
+
+    calculateWidth();
+    window.addEventListener('resize', calculateWidth);
+
+    return () => {
+      window.removeEventListener('resize', calculateWidth);
+    };
+  }, [data, calculateWidth]);
 
   const nextSlide = () => {
     if (isTransitioning) return;
     setIsTransitioning(true);
-
     if (currentIndex >= totalDataLength - offset) {
-      setCurrentIndex(currentIndex + 1);
-      setTimeout(() => {
-        setIsTransitioning(false);
-        setCurrentIndex(0);
-      }, 500);
+      setCurrentIndex(0);
     } else {
       setCurrentIndex(currentIndex + 1);
-      setTimeout(() => {
-        setIsTransitioning(false);
-      }, 500);
     }
+    setTimeout(() => setIsTransitioning(false), 500);
   };
 
   const prevSlide = () => {
     if (isTransitioning) return;
     setIsTransitioning(true);
-
     if (currentIndex <= 0) {
       setCurrentIndex(totalDataLength - offset);
-      setTimeout(() => {
-        setIsTransitioning(false);
-      }, 500);
     } else {
       setCurrentIndex(currentIndex - 1);
-      setTimeout(() => {
-        setIsTransitioning(false);
-      }, 500);
     }
+    setTimeout(() => setIsTransitioning(false), 500);
   };
+
   return {
     currentIndex,
     width,

--- a/src/hooks/useCarousel.jsx
+++ b/src/hooks/useCarousel.jsx
@@ -1,10 +1,4 @@
-import {
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  useCallback,
-} from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 /**
  * @typedef {Object} CarouselOptions
  * @property {number} totalDataLength - 캐러셀에 표시할 전체 데이터 항목의 수

--- a/src/pages/main-page/index.jsx
+++ b/src/pages/main-page/index.jsx
@@ -1,9 +1,6 @@
 import { getDonate } from '@apis/donateApi';
 import { useEffect, useState } from 'react';
 import DonateCarousel from './sections/DonateCarousel';
-import { IdolDate } from '@mocks/Idoldata';
-
-// const data = IdolDate();
 
 export default function MainPage() {
   const [idolData, setIdolData] = useState();

--- a/src/pages/main-page/index.jsx
+++ b/src/pages/main-page/index.jsx
@@ -1,7 +1,9 @@
-
 import { getDonate } from '@apis/donateApi';
 import { useEffect, useState } from 'react';
 import DonateCarousel from './sections/DonateCarousel';
+import { IdolDate } from '@mocks/Idoldata';
+
+// const data = IdolDate();
 
 export default function MainPage() {
   const [idolData, setIdolData] = useState();

--- a/src/pages/main-page/index.jsx
+++ b/src/pages/main-page/index.jsx
@@ -1,6 +1,5 @@
 import { getDonate } from '@apis/donateApi';
 import { useEffect, useState } from 'react';
-import DonateCarousel from './sections/DonateCarousel';
 
 export default function MainPage() {
   const [idolData, setIdolData] = useState();
@@ -13,10 +12,5 @@ export default function MainPage() {
 
     fetchDonateData();
   }, []);
-  return (
-    <div>
-      Main
-      <DonateCarousel idolData={idolData} />
-    </div>
-  );
+  return <div>main</div>;
 }

--- a/src/pages/main-page/sections/DonateCarousel.jsx
+++ b/src/pages/main-page/sections/DonateCarousel.jsx
@@ -9,7 +9,7 @@ const DonateCarousel = ({ idolData }) => {
       <Carousel
         data={idolData}
         RenderComponent={IdolCardList}
-        button={<Button btnText='후원하기' />}
+        button={<Button color='pink'>후원하기</Button>}
       />
     </div>
   );


### PR DESCRIPTION
### 📌 관련 이슈
- #64 
### 📋 작업 내용
- 캐러셀이 반응형으로 동작하도록 변경하였습니다.
- breakpoint에 맞게 보여주는 카드의 개수가 변경됩니다.
- 데이터를 불러오기 전에 useRef가 제대로 동작하지 않아서 캐러셀이 동작하지 않는 버그가 있었습니다. 이를 수정하였습니다.

### 📷 결과 및 스크린샷
![image](https://github.com/user-attachments/assets/f3c9cd3c-6d7f-4d9a-b99f-0f5290d16222)

![image](https://github.com/user-attachments/assets/8a737830-8726-4337-a694-80f09cfe513c)
![image](https://github.com/user-attachments/assets/a2e71338-74bd-40eb-ae37-1bcfca988e05)
![image](https://github.com/user-attachments/assets/22db424a-709e-4e14-8835-0c5a27d8d4ce)



### 🔎 참고 (선택)
- 아직 이미지 카드가 조금 겹쳐 이건 카드 이미지 크기도 반응형으로 조금 변해야 할 것 같습니다. 
- 캐러셀의 원활한 동작을 위해서 먼저 PR을 올립니다.