### PR TITLE
#123 Toast 컴포넌트 중복 style 제거

### DIFF
--- a/src/components/common/Toast.jsx
+++ b/src/components/common/Toast.jsx
@@ -29,7 +29,6 @@ const Toast = () => {
         style: {
           background: '#fff',
           color: '#363636',
-          borderRadius: '8px',
           padding: '20px',
           boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
           fontSize: '1.3rem',


### PR DESCRIPTION
### 📌 관련 이슈
- #123

### 📋 작업 내용
- Toast 컴포넌트에서 기본 토스트 스타일에 `borderRadius`가 중복되어 있던 부분을 삭제했습니다.

### 📷 결과 및 스크린샷
- 

### 🔎 참고 (선택)
