### PR TITLE
#118 메인페이지 리팩토링

### DIFF
--- a/src/components/card/IdolCard.jsx
+++ b/src/components/card/IdolCard.jsx
@@ -128,7 +128,7 @@ const IdolCardText = () => {
   const { location, title, size } = useContext(IdolCardContext);
 
   const locationClassName = cn(
-    'mb-2 text-[var(--color-gray-300)]',
+    'mb-2 text-[var(--color-gray-300)] truncate',
     size === 's' ? 'caption-text' : 'content-text',
   );
 

--- a/src/components/card/IdolCard.jsx
+++ b/src/components/card/IdolCard.jsx
@@ -87,6 +87,7 @@ const IdolCardList = ({
   size = 'm',
   button = null,
   children,
+  status,
 }) => {
   const contextValue = {
     id,
@@ -99,6 +100,7 @@ const IdolCardList = ({
     onClick,
     size,
     button,
+    status,
   };
 
   const IdolCardWrapClassName = cn(
@@ -149,11 +151,15 @@ const IdolCardText = () => {
  * - 버튼은 외부에서 JSX 컴포넌트로 전달되며, 클릭 핸들러(onClick)도 함께 전달됩니다.
  */
 const IdolCardImg = () => {
-  const { src, title, button, onClick } = useContext(IdolCardContext);
+  const { src, title, button, onClick, status } = useContext(IdolCardContext);
 
   // 버튼에 onClick 핸들러 연결
   const buttonWithHandler = button
-    ? React.cloneElement(button, { onClick })
+    ? React.cloneElement(button, {
+        onClick,
+        color: !status ? 'gray' : button.props.color, // status가 false면 color를 gray로
+        children: !status ? '상세 페이지 보기' : button.props.children, // 텍스트도 바꿔
+      })
     : null;
 
   return (

--- a/src/components/card/IdolCard.jsx
+++ b/src/components/card/IdolCard.jsx
@@ -166,7 +166,7 @@ const IdolCardImg = () => {
     <div className='relative'>
       <CardImg src={src} alt={title}>
         {button && (
-          <div className='absolute bottom-[1rem] left-1/2 z-10 -translate-x-1/2'>
+          <div className='absolute bottom-[1rem] left-1/2 z-10 -translate-x-1/2 '>
             {buttonWithHandler}
           </div>
         )}

--- a/src/components/card/IdolCard.jsx
+++ b/src/components/card/IdolCard.jsx
@@ -133,12 +133,12 @@ const IdolCardText = () => {
   );
 
   const titleClassName = cn(
-    size === 's' ? 'sub-content-text' : 'text-[1.8rem]',
+    size === 's' ? 'sub-content-text truncate' : 'text-[1.8rem] truncate',
   );
 
   return (
     <div className='pt-2 pb-6'>
-      <p className={locationClassName}>{location}</p>
+      <p className={locationClassName} >{location}</p>
       <p className={titleClassName}>{title}</p>
     </div>
   );

--- a/src/components/common/Carousel.jsx
+++ b/src/components/common/Carousel.jsx
@@ -100,6 +100,7 @@ const Carousel = ({ data, RenderComponent, button, ...props }) => {
                   title={item.title}
                   deadline={item.deadline}
                   button={button}
+                  status={item.status}
                 >
                   <IdolCardList.IdolCardFooter />
                 </RenderComponent>

--- a/src/components/common/Carousel.jsx
+++ b/src/components/common/Carousel.jsx
@@ -80,7 +80,7 @@ const Carousel = ({ data, RenderComponent, button, ...props }) => {
           }}
           transition={{
             type: 'tween',
-            duration: 0.5,
+            duration: 0.3,
           }}
         >
           {data.map((item) => (

--- a/src/components/common/Modal.jsx
+++ b/src/components/common/Modal.jsx
@@ -1,4 +1,5 @@
 import { AnimatePresence, motion } from 'motion/react';
+import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 
 /**
@@ -32,6 +33,16 @@ import { createPortal } from 'react-dom';
  */
 
 const Modal = ({ title, button, children, extra, isOpen, onClose }) => {
+  // 간단하게 body 스크롤 막기
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+
+      return () => {
+        document.body.style.overflow = '';
+      };
+    }
+  }, [isOpen]);
   return createPortal(
     <AnimatePresence mode='wait'>
       {isOpen && (

--- a/src/components/layouts/Header.jsx
+++ b/src/components/layouts/Header.jsx
@@ -10,34 +10,40 @@ export default function Header() {
   const { credit, handleChargeCredit } = useCredit();
   const creditModal = useModal();
   return (
-    <header className='relative z-101 m-auto flex h-[5rem] w-full items-center justify-center bg-black p-10 sm:h-[8rem]'>
+    <header className='relative z-50 m-auto flex h-[5rem] w-full items-center justify-center bg-black p-10 sm:h-[8rem]'>
       <div className='absolute top-0 z-101 m-auto flex h-[8rem] w-full max-w-[120rem] items-center justify-between bg-black px-20 sm:h-[8rem]'>
-        <div
-          onClick={creditModal.open}
-          className='p- cursor-pointer rounded-full border-[1.5px] border-white/50 px-4 py-3'
-        >
-          <p className='flex items-center text-xl font-bold text-white sm:text-xl'>
-            <CreditIcon className='mr-2 h-6 w-6' />
-            {credit || '0'}
-            <span className='hover:text-brand-1 transition-color ml-6 flex size-7 items-center justify-center rounded-full bg-white/30 leading-none text-black transition-all hover:bg-white'>
-              <PlusIcon />
-            </span>
-          </p>
+        <div className='flex w-1/3 justify-start'>
+          <div
+            onClick={creditModal.open}
+            className='cursor-pointer rounded-full border-[1.5px] border-white/50 px-2 py-1 sm:px-4 sm:py-3'
+          >
+            <p className='text flex items-center font-bold text-white sm:text-xl'>
+              <CreditIcon className='mr-2 h-4 w-6 sm:h-5 md:h-6' />
+              {credit || '0'}
+              <span className='hover:text-brand-1 transition-color sm:siz-6 ml-6 flex size-5 items-center justify-center rounded-full bg-white/30 leading-none text-black transition-all hover:bg-white md:size-7'>
+                <PlusIcon />
+              </span>
+            </p>
+          </div>
         </div>
-        <Link to='/main' className='flex items-center justify-center'>
-          <img
-            src={Logo}
-            alt='Fandom-K logo'
-            className='h-[3.5rem] sm:h-[4rem] md:h-[4.5rem]'
-          />
-        </Link>
-        <Link to='/mypage' className='flex items-center justify-center'>
-          <img
-            src={Default}
-            alt='empty profile Img'
-            className='h-[3.2rem] w-[3.2rem] rounded-full'
-          />
-        </Link>
+        <div className='flex w-1/3 justify-center'>
+          <Link to='/main' className='flex items-center justify-center'>
+            <img
+              src={Logo}
+              alt='Fandom-K logo'
+              className='h-[3rem] sm:h-[4rem] md:h-[4.5rem]'
+            />
+          </Link>
+        </div>
+        <div className='flex w-1/3 justify-end'>
+          <Link to='/mypage' className='flex items-center justify-center'>
+            <img
+              src={Default}
+              alt='empty profile Img'
+              className='size-[3rem] rounded-full sm:size-[4rem] md:size-[4.5rem]'
+            />
+          </Link>
+        </div>
       </div>
       <CreditModal
         creditModal={creditModal}

--- a/src/constants/buttonConstants.js
+++ b/src/constants/buttonConstants.js
@@ -5,6 +5,7 @@ const SIZE_STYLES = {
   m: 'h-[42px] w-[295px]  py-[9px]',
   s: 'h-[40px] w-[234px]  py-[8px]',
   xs: 'h-[31px] w-[142px]  py-[6px]',
+  card: `h-[4rem] w-[22rem] py-[8px]`
 };
 
 const COLOR_STYLES = {

--- a/src/hooks/useCarousel.js
+++ b/src/hooks/useCarousel.js
@@ -11,7 +11,7 @@ import { useEffect, useRef, useState, useCallback } from 'react';
  * @property {number} width - 각 캐러셀 항목의 너비 (픽셀셀)
  */
 
-const DURATION = 500;
+const DURATION = 300;
 
 export const useCarousel = ({ totalDataLength, offset, data, gap = '20' }) => {
   // 보여줄 페이지 위치

--- a/src/pages/main-page/components/ChartErrorMessage.jsx
+++ b/src/pages/main-page/components/ChartErrorMessage.jsx
@@ -6,10 +6,10 @@ const ErrorMessage = ({ onRetry }) => {
       <div className='text-brand-2 mb-4 text-3xl font-bold'>
         데이터를 불러오는데 실패했습니다
       </div>
-      <p className='mb-6 text-2xl text-gray-600'>
+      <p className='mb-6 text-2xl text-gray-50'>
         잠시 후 다시 시도하거나 아래 버튼을 클릭해주세요.
       </p>
-      <Button color='pink' size='s' btnType='button' onClick={onRetry}>
+      <Button color='gray' size='full' btnType='button' onClick={onRetry}>
         다시 시도하기
       </Button>
     </div>

--- a/src/pages/main-page/components/ChartErrorMessage.jsx
+++ b/src/pages/main-page/components/ChartErrorMessage.jsx
@@ -9,7 +9,7 @@ const ErrorMessage = ({ onRetry }) => {
       <p className='mb-6 text-2xl text-gray-50'>
         잠시 후 다시 시도하거나 아래 버튼을 클릭해주세요.
       </p>
-      <Button color='gray' size='full' btnType='button' onClick={onRetry}>
+      <Button color='gray' size='s' btnType='button' onClick={onRetry}>
         다시 시도하기
       </Button>
     </div>

--- a/src/pages/main-page/components/ChartErrorMessage.jsx
+++ b/src/pages/main-page/components/ChartErrorMessage.jsx
@@ -2,14 +2,14 @@ import Button from '@components/common/Button';
 
 const ErrorMessage = ({ onRetry }) => {
   return (
-    <div className='flex min-h-[50rem] w-full flex-col items-center justify-center py-10'>
-      <div className='mb-4 text-xl font-bold text-red-500'>
+    <div className='flex min-h-[50rem] w-full flex-col items-center justify-center gap-5 py-10'>
+      <div className='text-brand-2 mb-4 text-3xl font-bold'>
         데이터를 불러오는데 실패했습니다
       </div>
-      <p className='mb-6 text-gray-600'>
+      <p className='mb-6 text-2xl text-gray-600'>
         잠시 후 다시 시도하거나 아래 버튼을 클릭해주세요.
       </p>
-      <Button color='pink' size='m' btnType='button' onClick={onRetry}>
+      <Button color='pink' size='s' btnType='button' onClick={onRetry}>
         다시 시도하기
       </Button>
     </div>

--- a/src/pages/main-page/components/CreditModal.jsx
+++ b/src/pages/main-page/components/CreditModal.jsx
@@ -2,13 +2,17 @@ import Modal from '@components/common/Modal';
 import CreditForm from '@components/credit-form/CreditForm';
 
 const CreditModal = ({ creditModal, credit, handleChargeCredit }) => {
+  const handleChargeAndClose = (amount) => {
+    handleChargeCredit(amount); // 크레딧 충전
+    creditModal.close(); // 모달 닫기
+  };
   return (
     <Modal
       isOpen={creditModal.isOpen}
       onClose={creditModal.close}
       title='크레딧 충전하기'
     >
-      <CreditForm credit={credit} onClick={handleChargeCredit} />
+      <CreditForm credit={credit} onClick={handleChargeAndClose} />
     </Modal>
   );
 };

--- a/src/pages/main-page/sections/DonateCarousel.jsx
+++ b/src/pages/main-page/sections/DonateCarousel.jsx
@@ -110,7 +110,7 @@ const DonateCarousel = ({ idolData, isLoading, fetchDonateData }) => {
   const { setDonationData } = useDonation();
 
   return (
-    <div className='my-20 flex w-full flex-col gap-10'>
+    <div className='mt-20 flex w-full flex-col gap-10'>
       <h1 className='title-text text-white'>후원을 기다리는 조공</h1>
 
       {/* 데이터 유무에 관계없이 일정한 높이를 가진 영역을 유지 */}

--- a/src/pages/main-page/sections/DonateCarousel.jsx
+++ b/src/pages/main-page/sections/DonateCarousel.jsx
@@ -130,7 +130,7 @@ const DonateCarousel = ({ idolData, isLoading, fetchDonateData }) => {
               />
             )}
             button={
-              <Button size='s' color='pink'>
+              <Button size='card' color='pink'>
                 후원하기
               </Button>
             }

--- a/src/pages/main-page/sections/DonateCarousel.jsx
+++ b/src/pages/main-page/sections/DonateCarousel.jsx
@@ -110,11 +110,11 @@ const DonateCarousel = ({ idolData, isLoading, fetchDonateData }) => {
   const { setDonationData } = useDonation();
 
   return (
-    <div className='flex w-full flex-col gap-10'>
+    <div className='my-20 flex w-full flex-col gap-10'>
       <h1 className='title-text text-white'>후원을 기다리는 조공</h1>
 
       {/* 데이터 유무에 관계없이 일정한 높이를 가진 영역을 유지 */}
-      <div className='min-h-[360px] w-full'>
+      <div className='min-h-[360px] w-full px-20'>
         {isLoading ? (
           <ResponsiveSkeletonCarousel />
         ) : idolData && idolData.length > 0 ? (

--- a/src/pages/main-page/sections/MonthlyChartSection.jsx
+++ b/src/pages/main-page/sections/MonthlyChartSection.jsx
@@ -3,8 +3,8 @@ import MonthlyChartTabs from '../components/MonthlyChartTabs';
 
 const MonthlyChartSection = ({ open }) => {
   return (
-    <div className='flex w-full max-w-[120rem] flex-col'>
-     <MonthlyChartHeader open={open} />
+    <div className='my-10 flex w-full max-w-[120rem] flex-col'>
+      <MonthlyChartHeader open={open} />
       <MonthlyChartTabs />
     </div>
   );


### PR DESCRIPTION
### 📌 관련 이슈
- #118 

### 📋 작업 내용
- 후원이 완료되면 캐러셀에서 버튼이 회색으로 변경되고, "상세페이지로 이동"으로 노출됩니다.
- 헤더의 QA를 진행하였습니다.
 로고 가운데 정렬
 크레딧 및 아바타 크기 조절
- 캐러셀 속도 증가
- 캐러셀 모바일 화면에서 양 옆의 공간 추
- 전체적인 섹션 사이 거리 추가
- 이달의 차트 데이터 수신 실패 시 경고 창 수

### 📷 결과 및 스크린샷
![image](https://github.com/user-attachments/assets/e75b1fbe-f61f-41e1-85fe-9546593d2609)
![image](https://github.com/user-attachments/assets/d4a2e2fe-055e-4dd1-9e48-52f895d6cb50)
![image](https://github.com/user-attachments/assets/4b8fb442-05cf-4326-ae84-d8bfb28527c1)
![image](https://github.com/user-attachments/assets/10ff8f5b-f6e5-4af3-b133-d1ae9649e687)




### 🔎 참고 (선택)
