### PR TITLE
#155 후원 상세 페이지 성능 개선

### DIFF
--- a/src/pages/detail-page/components/DonationInfo.jsx
+++ b/src/pages/detail-page/components/DonationInfo.jsx
@@ -233,7 +233,7 @@ const InfoProgressBar = ({ progress, children }) => {
   return (
     <div className='relative mt-5 mb-1 h-4 w-full rounded-full'>
       <div
-        className='bg-gradient-brand absolute z-1 flex h-4 items-center rounded-full'
+        className='bg-gradient-brand absolute z-1 flex h-4 items-center rounded-full text-black'
         style={{ width: `${progress}%` }}
       >
         {children}

--- a/src/pages/detail-page/sections/mobile/MainSection.jsx
+++ b/src/pages/detail-page/sections/mobile/MainSection.jsx
@@ -1,10 +1,17 @@
+import { lazy, Suspense } from 'react';
 import DonationInfo from '@pages/detail-page/components/DonationInfo';
 import MainTitle from '@pages/detail-page/components/MainTitle';
-import Button from '@components/common/Button';
 import useModal from '@hooks/useModal';
-import DonateModal from '@pages/detail-page/components/DonateModal';
-import DetailContent from '@pages/detail-page/components/DetailContent';
-import DetailTitle from '@pages/detail-page/components/DetailTitle';
+const DonateModal = lazy(
+  () => import('@pages/detail-page/components/DonateModal'),
+);
+const Button = lazy(() => import('@components/common/Button'));
+const DetailTitle = lazy(
+  () => import('@pages/detail-page/components/DetailTitle'),
+);
+const DetailContent = lazy(
+  () => import('@pages/detail-page/components/DetailContent'),
+);
 
 const MainSection = ({
   id,
@@ -25,14 +32,16 @@ const MainSection = ({
     <div className='flex h-[calc(100vh-8rem)] w-screen snap-y snap-mandatory flex-col items-center overflow-y-scroll bg-black'>
       {/* 아이돌 사진 배경 */}
       <section className='relative h-[calc(100vh-45rem)] w-full snap-start'>
-        <div
-          className='h-[calc(100vh-45rem)] w-screen bg-cover bg-center'
-          style={{
-            backgroundImage: `linear-gradient(to right, rgba(0,0,0,0) 0%, rgba(0,0,0,0.8) 100%), url('${idol.profilePicture}')`,
-          }}
-        ></div>
+        <div className='relative h-[calc(100vh-45rem)] w-screen overflow-hidden'>
+          <img
+            src={idol.profilePicture}
+            alt={`${idol.name} 배경 이미지`}
+            className='absolute inset-0 h-full w-full object-cover'
+          />
+          <div className='absolute inset-0 bg-gradient-to-r from-transparent to-black/80' />
+        </div>
         <div className='absolute bottom-0 h-full'>
-          <div className='inset-0 z-10 w-screen h-full bg-gradient-to-b from-transparent via-black/40 to-black'></div>
+          <div className='inset-0 z-10 h-full w-screen bg-gradient-to-b from-transparent via-black/40 to-black'></div>
         </div>
         <div className='absolute bottom-0 left-[5vw]'>
           <MainTitle title={title} name={englishName} size='s' />
@@ -67,16 +76,20 @@ const MainSection = ({
       </section>
 
       {/* 후원 상세 정보 */}
-      <section className='relative flex justify-center w-screen pt-10 h-fit snap-start'>
+      <section className='relative flex h-fit w-screen snap-start justify-center pt-10'>
         <div className='mt-10 mb-20 w-[90vw]'>
-          <DetailTitle
-            name={`${idol.group} ${idol.name}`}
-            title={title}
-            location={subtitle}
-            size='s'
-          />
+          <Suspense fallback={null}>
+            <DetailTitle
+              name={`${idol.group} ${idol.name}`}
+              title={title}
+              location={subtitle}
+              size='s'
+            />
+          </Suspense>
 
-          <DetailContent contents={contents} />
+          <Suspense fallback={null}>
+            <DetailContent contents={contents} />
+          </Suspense>
         </div>
       </section>
 
@@ -84,36 +97,42 @@ const MainSection = ({
       <div className='fixed bottom-0 z-30 flex h-[13rem] w-screen items-end justify-center bg-gradient-to-b from-transparent via-black/80 to-black pb-6'>
         <div className='w-[90vw]'>
           {isDonationOpen ? (
-            <Button
-              color='pink'
-              size='full'
-              className='rounded hover:bg-black'
-              onClick={open}
-            >
-              후원하기
-            </Button>
+            <Suspense fallback={null}>
+              <Button
+                color='pink'
+                size='full'
+                className='rounded hover:bg-black'
+                onClick={open}
+              >
+                후원하기
+              </Button>
+            </Suspense>
           ) : (
-            <Button
-              color='gray'
-              size='full'
-              className='rounded hover:bg-black'
-              disabled
-            >
-              모집 종료
-            </Button>
+            <Suspense fallback={null}>
+              <Button
+                color='gray'
+                size='full'
+                className='rounded hover:bg-black'
+                disabled
+              >
+                모집 종료
+              </Button>
+            </Suspense>
           )}
 
-          <DonateModal
-            isOpen={isModalOpen}
-            close={close}
-            donateId={id}
-            cardItem={{
-              id: idol.id,
-              title: title,
-              subtitle: subtitle,
-              profilePicture: idol.profilePicture,
-            }}
-          />
+          <Suspense fallback={null}>
+            <DonateModal
+              isOpen={isModalOpen}
+              close={close}
+              donateId={id}
+              cardItem={{
+                id: idol.id,
+                title: title,
+                subtitle: subtitle,
+                profilePicture: idol.profilePicture,
+              }}
+            />
+          </Suspense>
         </div>
       </div>
     </div>

--- a/src/pages/detail-page/sections/pc/MainSection.jsx
+++ b/src/pages/detail-page/sections/pc/MainSection.jsx
@@ -1,15 +1,25 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, lazy, Suspense } from 'react';
 import { motion } from 'motion/react';
 import useElementHeight from '@hooks/useElementHeight';
 import DonationInfo from '@pages/detail-page/components/DonationInfo';
 import MainTitle from '@pages/detail-page/components/MainTitle';
-import Button from '@components/common/Button';
-import DetailTitle from '@pages/detail-page/components/DetailTitle';
-import DetailContent from '@pages/detail-page/components/DetailContent';
 import useScrollAnimation from '@hooks/useScrollAnimation';
 import useModal from '@hooks/useModal';
-import DonateModal from '@pages/detail-page/components/DonateModal';
-import ViewDetailButton from '@pages/detail-page/components/ViewDetailButton';
+
+// MainTitle은 LCP에 해당하기 때문에 Lazy Loading 처리 X
+const DonateModal = lazy(
+  () => import('@pages/detail-page/components/DonateModal'),
+);
+const ViewDetailButton = lazy(
+  () => import('@pages/detail-page/components/ViewDetailButton'),
+);
+const Button = lazy(() => import('@components/common/Button'));
+const DetailTitle = lazy(
+  () => import('@pages/detail-page/components/DetailTitle'),
+);
+const DetailContent = lazy(
+  () => import('@pages/detail-page/components/DetailContent'),
+);
 
 const MainSection = ({
   id,
@@ -75,15 +85,21 @@ const MainSection = ({
               style={{ top: `calc(100vh - 10rem - ${titleHeight}px)` }}
             >
               <div className='absolute top-[-5rem] left-1/2 mb-10'>
-                <ViewDetailButton isVisible={isHovered} />
+                <Suspense fallback={null}>
+                  <ViewDetailButton isVisible={isHovered} />
+                </Suspense>
               </div>
 
               <div className='h-fit snap-end' ref={titleRef}>
-                <MainTitle title={title} name={englishName} size='l' />
+                <Suspense fallback={null}>
+                  <MainTitle title={title} name={englishName} size='l' />
+                </Suspense>
               </div>
 
               <div className='snap-start pb-10'>
-                <DetailContent contents={contents} />
+                <Suspense fallback={null}>
+                  <DetailContent contents={contents} />
+                </Suspense>
               </div>
             </div>
           </section>
@@ -96,12 +112,14 @@ const MainSection = ({
               ref={donationInfoRef}
             >
               <motion.div style={detailTitleAnimation} ref={donationInfoRef}>
-                <DetailTitle
-                  name={`${idol.group} ${idol.name}`}
-                  title={title}
-                  location={subtitle}
-                  size='l'
-                />
+                <Suspense fallback={null}>
+                  <DetailTitle
+                    name={`${idol.group} ${idol.name}`}
+                    title={title}
+                    location={subtitle}
+                    size='l'
+                  />
+                </Suspense>
               </motion.div>
 
               <div className='mt-20 flex flex-col gap-10'>
@@ -133,36 +151,42 @@ const MainSection = ({
 
             <div>
               {isDonationOpen ? (
-                <Button
-                  color='pink'
-                  size='full'
-                  className='rounded hover:bg-black'
-                  onClick={open}
-                >
-                  후원하기
-                </Button>
+                <Suspense fallback={null}>
+                  <Button
+                    color='pink'
+                    size='full'
+                    className='rounded hover:bg-black'
+                    onClick={open}
+                  >
+                    후원하기
+                  </Button>
+                </Suspense>
               ) : (
-                <Button
-                  color='gray'
-                  size='full'
-                  className='rounded hover:bg-black'
-                  disabled
-                >
-                  모집 종료
-                </Button>
+                <Suspense fallback={null}>
+                  <Button
+                    color='gray'
+                    size='full'
+                    className='rounded hover:bg-black'
+                    disabled
+                  >
+                    모집 종료
+                  </Button>
+                </Suspense>
               )}
 
-              <DonateModal
-                isOpen={isModalOpen}
-                close={close}
-                donateId={id}
-                cardItem={{
-                  id: idol.id,
-                  title: title,
-                  subtitle: subtitle,
-                  profilePicture: idol.profilePicture,
-                }}
-              />
+              <Suspense fallback={null}>
+                <DonateModal
+                  isOpen={isModalOpen}
+                  close={close}
+                  donateId={id}
+                  cardItem={{
+                    id: idol.id,
+                    title: title,
+                    subtitle: subtitle,
+                    profilePicture: idol.profilePicture,
+                  }}
+                />
+              </Suspense>
             </div>
           </section>
         </div>

--- a/src/pages/detail-page/sections/tablet/MainSection.jsx
+++ b/src/pages/detail-page/sections/tablet/MainSection.jsx
@@ -1,14 +1,23 @@
-import { useState } from 'react';
+import { useState, lazy, Suspense } from 'react';
 import { motion, useScroll, useTransform } from 'motion/react';
 import useElementHeight from '@hooks/useElementHeight';
 import DonationInfo from '@pages/detail-page/components/DonationInfo';
 import MainTitle from '@pages/detail-page/components/MainTitle';
-import Button from '@components/common/Button';
-import DetailTitle from '@pages/detail-page/components/DetailTitle';
-import DetailContent from '@pages/detail-page/components/DetailContent';
 import useModal from '@hooks/useModal';
-import DonateModal from '@pages/detail-page/components/DonateModal';
-import ViewDetailButton from '@pages/detail-page/components/ViewDetailButton';
+
+const DonateModal = lazy(
+  () => import('@pages/detail-page/components/DonateModal'),
+);
+const ViewDetailButton = lazy(
+  () => import('@pages/detail-page/components/ViewDetailButton'),
+);
+const Button = lazy(() => import('@components/common/Button'));
+const DetailTitle = lazy(
+  () => import('@pages/detail-page/components/DetailTitle'),
+);
+const DetailContent = lazy(
+  () => import('@pages/detail-page/components/DetailContent'),
+);
 
 const MainSection = ({
   id,
@@ -55,7 +64,9 @@ const MainSection = ({
             style={{ marginTop: `calc(100vh - 8rem - ${titleHeight}px)` }}
           >
             <div className='absolute top-[-5rem] left-1/2'>
-              <ViewDetailButton isVisible={isHovered} />
+              <Suspense fallback={null}>
+                <ViewDetailButton isVisible={isHovered} />
+              </Suspense>
             </div>
 
             <div ref={titleRef}>
@@ -63,16 +74,20 @@ const MainSection = ({
             </div>
 
             <div className='my-20'>
-              <DetailTitle
-                name={`${idol.group} ${idol.name}`}
-                title={title}
-                location={subtitle}
-                size='s'
-              />
+              <Suspense fallback={null}>
+                <DetailTitle
+                  name={`${idol.group} ${idol.name}`}
+                  title={title}
+                  location={subtitle}
+                  size='s'
+                />
+              </Suspense>
             </div>
 
             <div className='pb-10'>
-              <DetailContent contents={contents} />
+              <Suspense fallback={null}>
+                <DetailContent contents={contents} />
+              </Suspense>
             </div>
           </div>
         </section>
@@ -107,37 +122,43 @@ const MainSection = ({
 
             <motion.div style={{ y: donationButtonY }}>
               {isDonationOpen ? (
-                <Button
-                  color='pink'
-                  size='full'
-                  className='rounded hover:bg-black'
-                  onClick={open}
-                >
-                  후원하기
-                </Button>
+                <Suspense fallback={null}>
+                  <Button
+                    color='pink'
+                    size='full'
+                    className='rounded hover:bg-black'
+                    onClick={open}
+                  >
+                    후원하기
+                  </Button>
+                </Suspense>
               ) : (
-                <Button
-                  color='gray'
-                  size='full'
-                  className='rounded hover:bg-black'
-                  disabled
-                >
-                  모집 종료
-                </Button>
+                <Suspense fallback={null}>
+                  <Button
+                    color='gray'
+                    size='full'
+                    className='rounded hover:bg-black'
+                    disabled
+                  >
+                    모집 종료
+                  </Button>
+                </Suspense>
               )}
             </motion.div>
 
-            <DonateModal
-              isOpen={isModalOpen}
-              close={close}
-              donateId={id}
-              cardItem={{
-                id: idol.id,
-                title: title,
-                subtitle: subtitle,
-                profilePicture: idol.profilePicture,
-              }}
-            />
+            <Suspense fallback={null}>
+              <DonateModal
+                isOpen={isModalOpen}
+                close={close}
+                donateId={id}
+                cardItem={{
+                  id: idol.id,
+                  title: title,
+                  subtitle: subtitle,
+                  profilePicture: idol.profilePicture,
+                }}
+              />
+            </Suspense>
           </div>
         </section>
       </div>


### PR DESCRIPTION
### 📌 관련 이슈
- #155

### 📋 작업 내용
- 후원 상세 페이지에 Lazy Loading 적용
- 후원 정보 컴포넌트의 진행률의 접근성 개선

### 📷 결과 및 스크린샷
- LightHouse (PC) 
  - 최종적으로 `Performance : 89` / `Accessibility : 100` / `Best Pratices : 100` / `SEO : 92`로 개선하였습니다. 
  - SEO는 `robots.txt is valid` 문제로, 은빈님께서 최적화하신 부분이 그대로 적용될 것 같아서 이번 PR에 적용시키지 않았습니다.
- 정말 여러 방법을 다 써봤음에도 Performace 점수가 잘 안오르네요...ㅠ
<img width="424" alt="image" src="https://github.com/user-attachments/assets/b138202b-bc21-463e-8c9b-9f32724d7c6d" />


### 🔎 참고 (선택)
